### PR TITLE
sed substitution was wrong

### DIFF
--- a/build
+++ b/build
@@ -54,7 +54,6 @@ tar -xzvf ${NPS_VERSION}.tar.gz  # extracts to psol/
 # now enable pagespeed module in debian/rules
 sed -i "s/.\/configure /.\/configure --add-module=modules\/ngx_pagespeed-release-${NPS_VERSION}-beta /g" $NGINX_BUILD_DIR/debian/rules
 
-
 # build deb
 cd $NGINX_BUILD_DIR
 dpkg-buildpackage -b

--- a/build
+++ b/build
@@ -52,7 +52,8 @@ wget https://dl.google.com/dl/page-speed/psol/${NPS_VERSION}.tar.gz
 tar -xzvf ${NPS_VERSION}.tar.gz  # extracts to psol/
 
 # now enable pagespeed module in debian/rules
-sed -i "s/.\ \/configure /.\/configure --add-module=modules\/ngx_pagespeed-${NPS_VERSION}-beta /g" $NGINX_BUILD_DIR/debian/rules
+sed -i "s/.\/configure /.\/configure --add-module=modules\/ngx_pagespeed-release-${NPS_VERSION}-beta /g" $NGINX_BUILD_DIR/debian/rules
+
 
 # build deb
 cd $NGINX_BUILD_DIR

--- a/build
+++ b/build
@@ -52,7 +52,7 @@ wget https://dl.google.com/dl/page-speed/psol/${NPS_VERSION}.tar.gz
 tar -xzvf ${NPS_VERSION}.tar.gz  # extracts to psol/
 
 # now enable pagespeed module in debian/rules
-sed -i "s/\.\/configure /. \/configure --add-module=modules\/ngx_pagespeed-${NPS_VERSION}-beta /g" $NGINX_BUILD_DIR/debian/rules
+sed -i "s/.\ \/configure /.\/configure --add-module=modules\/ngx_pagespeed-${NPS_VERSION}-beta /g" $NGINX_BUILD_DIR/debian/rules
 
 # build deb
 cd $NGINX_BUILD_DIR


### PR DESCRIPTION
The `sed s/` was not matching the string on _**debian/rules**_ and the pagespeed folder inside modules has a diferent name.
